### PR TITLE
Including support for JCheckBoxMenuItems

### DIFF
--- a/src/com/palantir/ptoss/cinch/swing/AbstractButtonWiringHarness.java
+++ b/src/com/palantir/ptoss/cinch/swing/AbstractButtonWiringHarness.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 
 import javax.swing.AbstractButton;
 import javax.swing.JCheckBox;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JToggleButton;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.ptoss.cinch.core.BindableModel;
@@ -32,35 +34,36 @@ import com.palantir.ptoss.cinch.swing.Bound.Wiring;
 import com.palantir.ptoss.util.Mutator;
 
 /**
- * A {@link WiringHarness} for binding a {@link JCheckBox} to a boolean value in a
- * {@link BindableModel}.
+ * A {@link WiringHarness} for binding an {@link AbstractButton}, such as a
+ * {@link JCheckBox}, {@link JToggleButton}, or {@link JCheckBoxMenuItem},
+ * to a boolean value in a {@link BindableModel}.
  */
-public class JCheckBoxWiringHarness implements WiringHarness<Bound, Field> {
+public class AbstractButtonWiringHarness implements WiringHarness<Bound, Field> {
 
     public Collection<Binding> wire(Bound bound, BindingContext context, Field field)
             throws IllegalAccessException, IntrospectionException {
         Mutator mutator = Mutator.create(context, bound.to());
-        JCheckBox checkbox = context.getFieldObject(field, JCheckBox.class);
-        return ImmutableList.of(bindJCheckBox(mutator, checkbox));
+        AbstractButton abstractButton = context.getFieldObject(field, AbstractButton.class);
+        return ImmutableList.of(bindAbstractButton(mutator, abstractButton));
     }
 
-    public static Binding bindJCheckBox(
-            final Mutator mutator, final AbstractButton checkbox) {
-        checkbox.addActionListener(new ActionListener() {
+    public static Binding bindAbstractButton(
+            final Mutator mutator, final AbstractButton abstractButton) {
+    	abstractButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 try {
-                    mutator.set(checkbox.isSelected());
+                    mutator.set(abstractButton.isSelected());
                 } catch (Exception ex) {
-                    Wiring.logger.error("exception in JCheckBox binding", ex);
+                    Wiring.logger.error("exception in AbstractButton binding", ex);
                 }
             }
         });
         Binding binding = new Binding() {
             public <T extends Enum<?> & ModelUpdate> void update(T... changed) {
                 try {
-                    checkbox.setSelected((Boolean)mutator.get());
+                	abstractButton.setSelected((Boolean)mutator.get());
                 } catch (Exception ex) {
-                    Wiring.logger.error("exception in JCheckBox binding", ex);
+                    Wiring.logger.error("exception in AbstractButton binding", ex);
                 }
             }
         };

--- a/src/com/palantir/ptoss/cinch/swing/Bound.java
+++ b/src/com/palantir/ptoss/cinch/swing/Bound.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import javax.swing.JCheckBox;
+import javax.swing.AbstractButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -128,7 +128,7 @@ public @interface Bound {
 
         private static Map<Class<?>, WiringHarness<Bound, Field>> wiringHarnesses =
             ImmutableMap.<Class<?>, WiringHarness<Bound, Field>>builder()
-                .put(JCheckBox.class, new JCheckBoxWiringHarness())
+                .put(AbstractButton.class, new AbstractButtonWiringHarness())
                 .put(JRadioButton.class, new JToggleButtonWiringHarness())
                 .put(JToggleButton.class, new JToggleButtonWiringHarness())
                 .put(JSlider.class, new JSliderWiringHarness())

--- a/src/com/palantir/ptoss/cinch/swing/JToggleButtonWiringHarness.java
+++ b/src/com/palantir/ptoss/cinch/swing/JToggleButtonWiringHarness.java
@@ -53,7 +53,7 @@ public class JToggleButtonWiringHarness implements WiringHarness<Bound, Field> {
         } else if (paramTypes.length == 1 && paramTypes[0] == boolean.class) {
             String value = bound.value();
             if (Strings.isNullOrEmpty(value)) {
-                return ImmutableList.of(JCheckBoxWiringHarness.bindJCheckBox(mutator, toggle));
+                return ImmutableList.of(AbstractButtonWiringHarness.bindAbstractButton(mutator, toggle));
             } else {
                 return ImmutableList.of(bindJToggleButtonToBoolean(bound.value(), mutator, toggle));
             }

--- a/test/com/palantir/ptoss/cinch/AllCinchTests.java
+++ b/test/com/palantir/ptoss/cinch/AllCinchTests.java
@@ -45,6 +45,7 @@ public class AllCinchTests {
         suite.addTestSuite(BoundJComboBoxTest.class);
         suite.addTestSuite(BoundJProgressBarTest.class);
         suite.addTestSuite(BoundJCheckBoxTest.class);
+        suite.addTestSuite(BoundJCheckBoxMenuItemTest.class);
         suite.addTestSuite(BoundJToggleButtonTest.class);
         suite.addTestSuite(BoundJSliderTest.class);
         suite.addTestSuite(BoundJTextComponentTest.class);

--- a/test/com/palantir/ptoss/cinch/BoundJCheckBoxMenuItemTest.java
+++ b/test/com/palantir/ptoss/cinch/BoundJCheckBoxMenuItemTest.java
@@ -1,0 +1,47 @@
+//   Copyright 2011 Palantir Technologies
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package com.palantir.ptoss.cinch;
+
+import javax.swing.JCheckBoxMenuItem;
+
+import junit.framework.TestCase;
+
+import com.palantir.ptoss.cinch.core.Bindings;
+import com.palantir.ptoss.cinch.swing.Bound;
+
+public class BoundJCheckBoxMenuItemTest extends TestCase {
+
+    final BooleanModel model = new BooleanModel();
+
+    @Bound(to = "state")
+    final JCheckBoxMenuItem menuItem = new JCheckBoxMenuItem();
+
+    final Bindings bindings = Bindings.standard();
+
+    @Override
+    protected void setUp() throws Exception {
+        bindings.bind(this);
+    }
+
+    public void testSimple() {
+        assertFalse(model.isState());
+        assertFalse(menuItem.isSelected());
+        model.setState(true);
+        assertTrue(menuItem.isSelected());
+        assertTrue(model.isState());
+        menuItem.doClick();
+        assertFalse(model.isState());
+        assertFalse(menuItem.isSelected());
+    }
+}


### PR DESCRIPTION
Refactored JCheckBoxWiringHarness to be AbstractButtonWiringHarness, since both JCheckBox and JCheckBoxMenuItem descend from AbstractButton.

--Andy
